### PR TITLE
Add a ruby starter project

### DIFF
--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -1,0 +1,11 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status

--- a/ruby/.rspec
+++ b/ruby/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in pairing_test.gemspec
+gemspec

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,0 +1,35 @@
+PATH
+  remote: .
+  specs:
+    pairing_test (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    rake (10.5.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.16)
+  pairing_test!
+  rake (~> 10.0)
+  rspec (~> 3.0)
+
+BUNDLED WITH
+   1.16.3

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,11 @@
+# Pairing Test Skeleton
+
+Pairing test starter project for Ruby. Put your Ruby code in the file `lib/pairing_test` and put your specs in `spec/pairing_test_spec` (thes tests use rspec but feel free to `bundle install` anything else). To experiment with that code, run `bin/console` for an interactive prompt or `bin/script` if you want to type anything into a file and run it with some logging.
+
+`lib` has been added to the `require` path so all imports inside the `lib` directory must be relative to this, e.g. `require "pairing_test/version"`.
+
+## Local usage
+
+To the developer: if you have never used Ruby on your mac you may need to install [bundler](https://bundler.io/) simply by running `gem install bundler`.
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/ruby/bin/console
+++ b/ruby/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "pairing_test"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/ruby/bin/script
+++ b/ruby/bin/script
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "pairing_test"
+
+# You can type anything in this file and just run `bin/script` to have it logged
+# for testing

--- a/ruby/bin/setup
+++ b/ruby/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/ruby/lib/pairing_test.rb
+++ b/ruby/lib/pairing_test.rb
@@ -1,0 +1,9 @@
+require "pairing_test/version"
+
+module PairingTest
+  class Main
+    def passes
+      true
+    end
+  end
+end

--- a/ruby/lib/pairing_test/version.rb
+++ b/ruby/lib/pairing_test/version.rb
@@ -1,0 +1,3 @@
+module PairingTest
+  VERSION = "0.1.0"
+end

--- a/ruby/pairing_test.gemspec
+++ b/ruby/pairing_test.gemspec
@@ -1,0 +1,34 @@
+
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "pairing_test/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "pairing_test"
+  spec.version       = PairingTest::VERSION
+  spec.authors       = ["RichieAHB"]
+  spec.email         = ["richard.beddington@guardian.co.uk"]
+
+  spec.summary       = "Pairing test skeleton"
+  spec.homepage      = "https://github.com/guardian/pairing-test-project"
+
+  # Prevent pushing this gem to RubyGems.org.
+  if spec.respond_to?(:metadata)
+    spec.metadata["allowed_push_host"] = ""
+  else
+    raise "RubyGems 2.0 or newer is required to protect against " \
+      "public gem pushes."
+  end
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  spec.bindir        = "exe"
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+end

--- a/ruby/spec/pairing_test_spec.rb
+++ b/ruby/spec/pairing_test_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe PairingTest do
+  it "the passes instance method returns true" do
+    expect(PairingTest::Main.new.passes).to eq(true)
+  end
+end

--- a/ruby/spec/spec_helper.rb
+++ b/ruby/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require "bundler/setup"
+require "pairing_test"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
This adds a Ruby starter project for those of us who want a standard library method for _every_ use case 👍 

To test this:
- `cd` into the `ruby` folder
- run `gem install bundler` if you don't have bundler
- run `bin/setup`
- run `rake` to check the tests are running, you should have 1 pass