### PR TITLE
.NET core 3

### DIFF
--- a/dot-net-core/Code/Code.csproj
+++ b/dot-net-core/Code/Code.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dot-net-core/Code/Code.csproj
+++ b/dot-net-core/Code/Code.csproj
@@ -5,8 +5,4 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Linq" Version="4.3.0" />
-  </ItemGroup>
-
 </Project>

--- a/dot-net-core/Test/Test.csproj
+++ b/dot-net-core/Test/Test.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dot-net-core/script/setup
+++ b/dot-net-core/script/setup
@@ -2,10 +2,4 @@
 
 set -e
 
-# The dotnet-sdk cask will install version 3.1 on macOS > Sierra
-# however this project uses version 2.2
-# See https://github.com/Homebrew/homebrew-cask/blob/master/Casks/dotnet-sdk.rb
-# See https://stackoverflow.com/questions/55387250/multiple-versions-of-net-core-on-macos-with-brew
-
-brew tap isen-ng/dotnet-sdk-versions
-brew cask install dotnet-sdk-2.2.100
+brew cask install dotnet-sdk


### PR DESCRIPTION
Also remove Linq as a nuget dependency (I had to add this previously with .NET core 2 but still don't really know why, it works fine without now).