### PR TITLE
Enable Metals by bumping Scala to 2.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,18 @@
+*.iml
+*.pyc
+
+# IDEs
 .idea
 .idea_modules
-*.iml
+.vscode
+
+# build files
 target
+.metals
+
+# vendor files
 node_modules
-*.pyc
+
+# System files
 .DS_Store
+

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -1,3 +1,3 @@
-scalaVersion := "2.12.6"
+scalaVersion := "2.13.6"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"


### PR DESCRIPTION
## What does this change?

Bumps Scala to a version supported by Metals.

Reorganises the ignore files to be more explicit, and adds the following:
- `.metals`
- `.vscode`

## How to test

Run Metals in VSCode

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->