### PR TITLE
Update `scalatest` to work with Scala 2.13

### DIFF
--- a/scala/.gitignore
+++ b/scala/.gitignore
@@ -1,0 +1,4 @@
+# Metals / builds
+.bloop
+.bsp
+metals.sbt

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -1,3 +1,3 @@
 scalaVersion := "2.13.6"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.9" % "test"

--- a/scala/src/test/scala/gu/com/MainTest.scala
+++ b/scala/src/test/scala/gu/com/MainTest.scala
@@ -1,8 +1,9 @@
 package gu.com
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.{AnyFlatSpec}
+import org.scalatest.matchers.should.{Matchers}
 
-class MainTest extends FlatSpec with Matchers {
+class MainTest extends AnyFlatSpec with Matchers {
   "whereWeLive" should "be Earth" in {
     Main.whereWeLive should be ("Earth")
   }


### PR DESCRIPTION
## What does this change?

- use the new `AnyFlatType` and `Matchers` from `scalatest`
- ignore Metals build files

Follow-up on #63

## How to test

`./script/test`

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->