### PR TITLE
Add readme/script for Python usage on Windows

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -2,10 +2,13 @@
 
 Skeleton project for Python.
 
-## Usage
+## Usage (on MacOS / Linux)
 - `./script/setup` to install dependencies (uses [homebrew](https://brew.sh/))
 - `./script/test` to run the tests
 
+## Usage (on Windows)
+- Install Python 3. You can either download from https://www.python.org/downloads/ or run `python` in a terminal to open Windows store Python download.
+- Run `./script/test.bat` in terminal to run tests
 
 ## Structure
 - Code located in [`pairing_exercise.py`](./pairing_exercise.py)

--- a/python/script/test.bat
+++ b/python/script/test.bat
@@ -1,0 +1,9 @@
+:: Setup python virtual environment if it doesn't already exist
+@echo off
+if not exist venv\ (
+    python -m venv .\venv
+)
+
+call .\venv\Scripts\activate.bat
+
+python -m unittest discover


### PR DESCRIPTION
## What does this change?

Adds a Windows .bat script for running the Python unit tests. Also adds a section to the Python README explaining how to use this new script (i.e install python 3 first)

## How to test

Check out on a Windows 10 machine and check that .bat script works.

## How can we measure success?

We save time when interviewing a candidate

## Have we considered potential risks?

.bat scripts have limited functionality compared to Powershell but unlike powershell can be run without having to run `set-executionpolicy unrestricted` as an Administrator first. For python the script is very short so this should be fine. However for other programming languages the scripts might be more complicated, so I think whether or not the language uses .bat scripts or .ps1 (powershell) scripts should be a per language choice that's highlighted in the README for that language.

## Screen Capture

Usage on VSCode on Windows 10
![python1](https://user-images.githubusercontent.com/3285072/150979000-0fa785c3-3fca-48f0-badb-f65858b2b16e.gif)
