### PR TITLE
Remove node version check from typescript-node

### DIFF
--- a/typescript-node/script/setup
+++ b/typescript-node/script/setup
@@ -2,18 +2,4 @@
 
 set -e
 
-red='\x1B[0;31m'
-plain='\x1B[0m' # No Color
-
-checkNodeVersion() {
-  runningNodeVersion=$(node -v)
-  requiredNodeVersion=$(cat .nvmrc)
-
-  if [ "$runningNodeVersion" != "$requiredNodeVersion" ]; then
-    echo -e "${red}Using wrong version of Node. Required ${requiredNodeVersion}. Running ${runningNodeVersion}.${plain}"
-    exit 1
-  fi
-}
-
-checkNodeVersion
 yarn


### PR DESCRIPTION

## What does this change?

Remove the node version check from the typescript-node project. This no longer works since we updated the `.nvmrc` to use `lts/*` in #101