### PR TITLE
Remove node check for javascript projects

### DIFF
--- a/javascript-esm/script/setup
+++ b/javascript-esm/script/setup
@@ -2,18 +2,4 @@
 
 set -e
 
-red='\x1B[0;31m'
-plain='\x1B[0m' # No Color
-
-checkNodeVersion() {
-  runningNodeVersion=$(node -v)
-  requiredNodeVersion=$(cat .nvmrc)
-
-  if [ "$runningNodeVersion" != "$requiredNodeVersion" ]; then
-    echo -e "${red}Using wrong version of Node. Required ${requiredNodeVersion}. Running ${runningNodeVersion}.${plain}"
-    exit 1
-  fi
-}
-
-checkNodeVersion
 yarn

--- a/javascript/script/setup
+++ b/javascript/script/setup
@@ -2,18 +2,4 @@
 
 set -e
 
-red='\x1B[0;31m'
-plain='\x1B[0m' # No Color
-
-checkNodeVersion() {
-  runningNodeVersion=$(node -v)
-  requiredNodeVersion=$(cat .nvmrc)
-
-  if [ "$runningNodeVersion" != "$requiredNodeVersion" ]; then
-    echo -e "${red}Using wrong version of Node. Required ${requiredNodeVersion}. Running ${runningNodeVersion}.${plain}"
-    exit 1
-  fi
-}
-
-checkNodeVersion
 yarn


### PR DESCRIPTION

## What does this change?

Similar to #117, this removes the check for javascript and javascript-esm projects. These checks were failing following the update to define `lts/*` in the `.nvmrc` in #101 
