### PR TITLE
feat(typescript): Add `start` script

### DIFF
--- a/typescript-node/README.md
+++ b/typescript-node/README.md
@@ -3,11 +3,9 @@
 Skeleton project for TypeScript (via NodeJS) with Jest for testing.
 
 ## Usage
-- `./script/setup` to install dependencies
-- `./script/test` to run the tests
+See the scripts in [`package.json`](./package.json) for available commands.
 
-### Other commands
-- `yarn watch` will constantly compile `index.ts` then execute the compiled version on every file change (for quick development feedback loop) using [tsc-watch](https://www.npmjs.com/package/tsc-watch) under the hood.
+Alternatively, if following the `script/<task>` pattern, see the `script` directory for available commands.
 
 ## Structure
 - Code located in [`index.ts`](./src/index.ts)

--- a/typescript-node/package.json
+++ b/typescript-node/package.json
@@ -3,9 +3,11 @@
   "version": "1.0.0",
   "description": "NodeJS & TypeScript skeleton project for Guardian pairing test",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "jest",
     "tsc": "tsc",
+    "start": "tsc && node ./dist/index.js",
     "watch": "tsc-watch --onSuccess 'node ./dist/index.js' --onFailure 'echo Beep! Compilation Failed' --compiler typescript/bin/tsc"
   },
   "devDependencies": {

--- a/typescript-node/src/index.ts
+++ b/typescript-node/src/index.ts
@@ -1,3 +1,5 @@
 const myConst = false;
 
 export { myConst };
+
+console.log(`The current time is ${new Date().toDateString()}`);


### PR DESCRIPTION
## What does this change?
In some recent interviews, candidates were surprised by the absence of a `start` script. Let's add one!