### PR TITLE
Small improvements to the TypeScript Node project skeleton

### DIFF
--- a/typescript-node/package.json
+++ b/typescript-node/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "NodeJS & TypeScript skeleton project for Guardian pairing test",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "jest",
     "tsc": "tsc",

--- a/typescript-node/tsconfig.json
+++ b/typescript-node/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "noUncheckedIndexedAccess": false, // disabled to prevent errors in C-style loops: https://github.com/guardian/coding-exercise-project/pull/111#discussion_r1481440786
     "outDir": "dist",
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node", "jest"]
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
## What does this change?

This PR makes a couple of small tweaks to the TypeScript Node project skeleton:

### Set `type` to `module` in package.json

This tells Node that this project uses es modules, and means the implementation can be run directly with:

`$ node src/index.ts`

if needed. 

### Add Node and Jest types to tsconfig.json

So that we don't get type errors when using Node standard library and jest functions.